### PR TITLE
Add root exception message first

### DIFF
--- a/src/validate.py
+++ b/src/validate.py
@@ -271,6 +271,7 @@ class Validator(object):
             exception (Exception): the exception that was thrown.
         """
         client = self.get_client_with_role('sns', self.role_arn)
+        tb = '\n'.join(traceback.format_exception(exception))
         client.publish(
             TopicArn=self.sns_topic,
             Message=f'{self.format} package {self.source_filename} is invalid',
@@ -293,7 +294,7 @@ class Validator(object):
                 },
                 'message': {
                     'DataType': 'String',
-                    'StringValue': '\n'.join(traceback.format_exception(exception)),
+                    'StringValue': f'{str(exception)}\n\n{tb}',
                 }
             })
         logging.debug('Failure notification sent.')

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -333,4 +333,4 @@ def test_deliver_failure_notification():
     assert message_body['MessageAttributes']['outcome']['Value'] == 'FAILURE'
     assert message_body['MessageAttributes']['refid']['Value'] == validator.refid
     assert message_body['MessageAttributes'][
-        'message']['Value'] == f'Exception: {exception_message}\n'
+        'message']['Value'] == f'{exception_message}\n\nException: {exception_message}\n'


### PR DESCRIPTION
Displays the string value of the original exception first, then the detailed traceback.

Fixes #15 