### PR TITLE
Update Base Docker Image to Alpine and Python 3.12

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: pip
 
       - name: Install pre-commit and pip-tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
 
       - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
     args:
       - --in-place
       - --aggressive
+      - --max-line-length=100
 - repo: https://github.com/pycqa/flake8
   rev: 7.3.0
   hooks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.11-alpine AS base
-RUN apt-get update && apt-get install -y mediaconch
+
+# Install base system requirements
+RUN apk add --no-cache mediaconch
+
 WORKDIR /code
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm AS base
+FROM python:3.11-alpine AS base
 RUN apt-get update && apt-get install -y mediaconch
 WORKDIR /code
 COPY requirements.txt .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.12-alpine AS base
 
 WORKDIR /code
 ENV BUILD_DIR=/code/build
+ENV ZENLIB_VERSION=v0.4.41
+ENV MEDIAINFOLIB_VERSION=v25.09
+ENV MEDIACONCH_VERSION=v25.04
 
 # Create build directory
 RUN mkdir ${BUILD_DIR}
@@ -29,9 +32,9 @@ RUN apk add --no-cache \
 
 # Clone ZenLib, MediaInfoLib and MediaConch_SourceCode
 RUN cd ${BUILD_DIR} && \
-    git clone https://github.com/MediaArea/ZenLib.git && \
-    git clone https://github.com/MediaArea/MediaInfoLib.git && \
-    git clone https://github.com/MediaArea/MediaConch_SourceCode.git
+    git clone --branch ${ZENLIB_VERSION} https://github.com/MediaArea/ZenLib.git && \
+    git clone --branch ${MEDIAINFOLIB_VERSION} https://github.com/MediaArea/MediaInfoLib.git && \
+    git clone --branch ${MEDIACONCH_VERSION} https://github.com/MediaArea/MediaConch_SourceCode.git
 
 # Build ZenLib
 RUN cd ${BUILD_DIR}/ZenLib/Project/GNU/Library && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,72 @@
 FROM python:3.12-alpine AS base
 
-# Install base system requirements
-RUN apk add --no-cache mediaconch
-
 WORKDIR /code
+ENV BUILD_DIR=/code/build
+
+# Create build directory
+RUN mkdir ${BUILD_DIR}
+
+# Install system requirements and dependencies for MediaConch
+RUN apk add --no-cache \
+    git \
+    automake \
+    autoconf \
+    libtool \
+    make \
+    g++ \
+    zlib \
+    libxml2 \
+    libxslt \
+    libxml2-dev \
+    libxslt-dev \
+    libevent-dev \
+    jansson-dev \
+    sqlite-dev \
+    libzen \
+    libzen-dev \
+    libmediainfo \
+    libmediainfo-dev
+
+# Clone ZenLib, MediaInfoLib and MediaConch_SourceCode
+RUN cd ${BUILD_DIR} && \
+    git clone https://github.com/MediaArea/ZenLib.git && \
+    git clone https://github.com/MediaArea/MediaInfoLib.git && \
+    git clone https://github.com/MediaArea/MediaConch_SourceCode.git
+
+# Build ZenLib
+RUN cd ${BUILD_DIR}/ZenLib/Project/GNU/Library && \
+    ./autogen.sh && \
+    ./configure --enable-static && \
+    make
+
+# Build MediaInfoLib
+RUN cd ${BUILD_DIR}/MediaInfoLib/Project/GNU/Library && \
+    ./autogen.sh && \
+    ./configure --enable-static && \
+    cp ${BUILD_DIR}/MediaInfoLib/Project/GNU/Library/libmediainfo-config /bin/ && \
+    cp ${BUILD_DIR}/ZenLib/Project/GNU/Library/libzen-config /bin/libzen-config && \
+    cp ${BUILD_DIR}/ZenLib/Project/GNU/Library/libtool /bin/libtool
+
+# Build MediaConch
+RUN cd ${BUILD_DIR}/MediaConch_SourceCode/Project/GNU/CLI && \
+    ./autogen.sh && \
+    ./configure && \
+    make
+
+# Move mediaconch to the bin folder
+RUN cp ${BUILD_DIR}/MediaConch_SourceCode/Project/GNU/CLI/.libs/mediaconch /bin/mediaconch
+
+# Cleanup ZenLib, MediaInfoLib and MediaConch_SourceCode repositories and temporary build tools
+RUN rm -rf ${BUILD_DIR} && \
+    rm /bin/libzen-config && \
+    rm /bin/libmediainfo-config && \
+    rm /bin/libtool
+
+# Install Python requirements
 COPY requirements.txt .
 RUN pip install -r requirements.txt
+
+# Add code
 COPY src src
 COPY mediaconch mediaconch
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine AS base
+FROM python:3.12-alpine AS base
 
 # Install base system requirements
 RUN apk add --no-cache mediaconch

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@ aws-assume-role-lib==2.10.0
     # via -r requirements.in
 bagit==1.9.0
     # via -r requirements.in
-boto3==1.40.45
+boto3==1.40.53
     # via
     #   -r requirements.in
     #   aws-assume-role-lib
-botocore==1.40.45
+botocore==1.40.53
     # via
     #   boto3
     #   s3transfer

--- a/src/validate.py
+++ b/src/validate.py
@@ -299,9 +299,7 @@ class Validator(object):
         client = self.get_client_with_role('sns', self.role_arn)
         client.publish(
             TopicArn=self.sns_topic,
-            Message=f'{
-                self.format} package {
-                self.source_filename} successfully validated',
+            Message=f'{self.format} package {self.source_filename} successfully validated',
             MessageAttributes={
                 'format': {
                     'DataType': 'String',

--- a/src/validate.py
+++ b/src/validate.py
@@ -299,7 +299,9 @@ class Validator(object):
         client = self.get_client_with_role('sns', self.role_arn)
         client.publish(
             TopicArn=self.sns_topic,
-            Message=f'{self.format} package {self.source_filename} successfully validated',
+            Message=f'{
+                self.format} package {
+                self.source_filename} successfully validated',
             MessageAttributes={
                 'format': {
                     'DataType': 'String',

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py311, linting
+envlist = py312, linting
 skipsdist = True
 
 [testenv]
 skip_install = True
 
-[testenv:py311]
+[testenv:py312]
 allowlist_externals = docker
 passenv =
   USER

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ passenv =
   USER
 commands =
   docker build -t digitized_av_validation_test --target test .
-  docker run digitized_av_validation_test bash -c "coverage run -m pytest -s && coverage report -m"
+  docker run digitized_av_validation_test sh -c "coverage run -m pytest -s && coverage report -m"
 
 [testenv:linting]
 allowlist_externals = pre-commit


### PR DESCRIPTION
Mediaconch isn't available as a default Alpine apk package, so the Dockerfile includes steps to build MediaConch and associated dependencies from the source: https://github.com/MediaArea/MediaConch_SourceCode

This update also caused issues with autopep8's default 79 character line length, so I extended it to 100. I think this may be related to a change in [how python 3.12 handles f-strings](https://docs.python.org/3/whatsnew/3.12.html#pep-701-syntactic-formalization-of-f-strings), but I'm not 100% sure.